### PR TITLE
feat: added bun.js as an option

### DIFF
--- a/content/docker/javascript/bunjs/dockerfile
+++ b/content/docker/javascript/bunjs/dockerfile
@@ -1,0 +1,38 @@
+# use the official Bun image
+# see all versions at https://hub.docker.com/r/oven/bun/tags
+FROM oven/bun:@{BUN_VERSION} as base
+WORKDIR /usr/src/app
+
+# install dependencies into temp directory
+# this will cache them and speed up future builds
+FROM base AS install
+RUN mkdir -p /temp/dev
+COPY package.json bun.lockb /temp/dev/
+RUN cd /temp/dev && bun install --frozen-lockfile
+
+# install with --production (exclude devDependencies)
+RUN mkdir -p /temp/prod
+COPY package.json bun.lockb /temp/prod/
+RUN cd /temp/prod && bun install --frozen-lockfile --production
+
+# copy node_modules from temp directory
+# then copy all (non-ignored) project files into the image
+FROM base AS prerelease
+COPY --from=install /temp/dev/node_modules node_modules
+COPY . .
+
+# [optional] tests & build
+ENV NODE_ENV=production
+RUN bun test
+RUN bun run build
+
+# copy production dependencies and source code into final image
+FROM base AS release
+COPY --from=install /temp/prod/node_modules node_modules
+COPY --from=prerelease /usr/src/app/@{APP_ENTRYPOINT}.
+COPY --from=prerelease /usr/src/app/package.json .
+
+# run the app
+USER bun
+EXPOSE @{PORT}
+ENTRYPOINT [ "bun", "run", "@{APP_ENTRYPOINT}" ]

--- a/content/docker/javascript/bunjs/dockerignore
+++ b/content/docker/javascript/bunjs/dockerignore
@@ -1,0 +1,15 @@
+node_modules
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+README.md
+LICENSE
+.vscode
+Makefile
+helm-charts
+.env
+.editorconfig
+.idea
+coverage*

--- a/content/docker/javascript/bunjs/readme.md
+++ b/content/docker/javascript/bunjs/readme.md
@@ -1,0 +1,19 @@
+To use this Dockerfile for your BunJS backend application,
+save the `Dockerfile` and `.dockerignore` in your project's
+root directory.
+
+You can now run the following command to build the docker image:
+
+```
+$ docker build --pull -t {APP_NAME} .
+```
+
+The `-t` flag lets us specify a name for the image, and `--pull` tells Docker to automatically download the latest version of the base image (oven/bun).
+
+To run the built docker image:
+
+```
+$ docker run -it -p @{PORT}:@{PORT} {APP_NAME}
+```
+
+You should now be able to open the app in your browser on the specified port.

--- a/content/docker/javascript/javascript.yml
+++ b/content/docker/javascript/javascript.yml
@@ -30,3 +30,16 @@ variants:
       - name:  'PORT'
         value: '3000'
 
+  - id: bunjs
+    name: Basic Bun.js Apps
+    description: Simple BunJS applications
+    files:
+      - dockerfile
+      - dockerignore
+    variables:
+      - name:  'BUN_VERSION'
+        value: 'latest'
+      - name:  'PORT'
+        value: '8080'
+      - name:  'APP_ENTRYPOINT'
+        value: 'index.ts'


### PR DESCRIPTION
Now Bun.js shows as an option along with Node.js and NestJS applications under Javascript. 
The `dockerfile` and `dockerignore` , both are edited with respect to Bun.js

![image](https://github.com/sheharyarn/cloudup.dev/assets/89251367/41d2c9f5-51dc-4aaa-81a7-0dffd398a086)
